### PR TITLE
エクササイズ開始時に表示されるWARNINGメッセージを解消

### DIFF
--- a/exercises/00_intro/intro1.rs
+++ b/exercises/00_intro/intro1.rs
@@ -20,7 +20,7 @@ fn main() {
     println!("このファイルは`exercises/00_intro/intro1.rs`にあります。確認してみてください。");
     println!("現在のエクササイズの進捗はターミナル上のプロセスバーで確認できます。");
     println!("ターミナル上のパスをクリックすればエクササイズのファイルを確認できます。");
-    println!("");
+    println!();
     println!("どうしても分からない場合には`solutions`に解答例のファイルがあるので確認してみてください。");
     println!("その他、修正点などあれば「https://github.com/sotanengel/rustlings-jp/issues」にて連絡いただければと思います。");
 }


### PR DESCRIPTION
以下のようなメッセージが表示されていたため解消しました。

```
warning: empty string literal in `println!`
  --> exercises/00_intro/intro1.rs:23:5
   |
23 |     println!("");
   |     ^^^^^^^^^--^
   |              |
   |              help: remove the empty string
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#println_empty_string
   = note: `#[warn(clippy::println_empty_string)]` on by default
```