### PR TITLE
09_strings の README.md の typo を修正

### DIFF
--- a/exercises/09_strings/README.md
+++ b/exercises/09_strings/README.md
@@ -5,4 +5,4 @@ Rustにはスライスの文字列(`&str`)と所有権のある文字列(`String
 
 # 補足情報
 
-- [Strings](hhttps://doc.rust-jp.rs/book-ja/ch08-02-strings.html)
+- [Strings](https://doc.rust-jp.rs/book-ja/ch08-02-strings.html)


### PR DESCRIPTION
09_strings の README.md に typo があったため修正しました。

確認よろしくお願いします。